### PR TITLE
Add config for setting Endpoints for S3 and Dynamo

### DIFF
--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -66,6 +66,9 @@ type Config struct {
 		//
 		// The table must have a primary key named "logID" of type binary.
 		Table string
+
+		// Endpoint is the base URL the AWS SDK will use to connect to DynamoDB.
+		Endpoint string
 	}
 
 	Logs []LogConfig
@@ -111,6 +114,9 @@ type LogConfig struct {
 	// S3Bucket is the name of the S3 bucket. This bucket must be dedicated to
 	// this specific log instance.
 	S3Bucket string
+
+	// S3Endpoint is the base URL the AWS SDK will use to connect to S3.
+	S3Endpoint string
 
 	// NotAfterStart is the start of the validity range for certificates
 	// accepted by this log instance, as and RFC 3339 date.
@@ -169,7 +175,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	db, err := ctlog.NewDynamoDBBackend(ctx, c.DynamoDB.Region, c.DynamoDB.Table, logger)
+	db, err := ctlog.NewDynamoDBBackend(ctx, c.DynamoDB.Region, c.DynamoDB.Table, c.DynamoDB.Endpoint, logger)
 	if err != nil {
 		logger.Error("failed to create DynamoDB backend", "err", err)
 		os.Exit(1)
@@ -187,7 +193,7 @@ func main() {
 			slog.String("log", lc.ShortName),
 		}))
 
-		b, err := ctlog.NewS3Backend(ctx, lc.S3Region, lc.S3Bucket, logger)
+		b, err := ctlog.NewS3Backend(ctx, lc.S3Region, lc.S3Bucket, lc.S3Endpoint, logger)
 		if err != nil {
 			logger.Error("failed to create backend", "err", err)
 			os.Exit(1)

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -67,7 +67,7 @@ type Config struct {
 		// The table must have a primary key named "logID" of type binary.
 		Table string
 
-		// Endpoint is the base URL the AWS SDK will use to connect to DynamoDB.
+		// Endpoint is the base URL the AWS SDK will use to connect to DynamoDB. Optional.
 		Endpoint string
 	}
 
@@ -115,7 +115,7 @@ type LogConfig struct {
 	// this specific log instance.
 	S3Bucket string
 
-	// S3Endpoint is the base URL the AWS SDK will use to connect to S3.
+	// S3Endpoint is the base URL the AWS SDK will use to connect to S3. Optional.
 	S3Endpoint string
 
 	// NotAfterStart is the start of the validity range for certificates

--- a/internal/ctlog/dynamodb.go
+++ b/internal/ctlog/dynamodb.go
@@ -25,7 +25,7 @@ type DynamoDBBackend struct {
 	log     *slog.Logger
 }
 
-func NewDynamoDBBackend(ctx context.Context, region, table string, l *slog.Logger) (*DynamoDBBackend, error) {
+func NewDynamoDBBackend(ctx context.Context, region, table, endpoint string, l *slog.Logger) (*DynamoDBBackend, error) {
 	counter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "dynamodb_requests_total",
@@ -58,7 +58,11 @@ func NewDynamoDBBackend(ctx context.Context, region, table string, l *slog.Logge
 	}
 
 	return &DynamoDBBackend{
-		client:  dynamodb.NewFromConfig(cfg),
+		client: dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+			if endpoint != "" {
+				o.BaseEndpoint = aws.String(endpoint)
+			}
+		}),
 		table:   table,
 		metrics: []prometheus.Collector{counter, duration},
 		log:     l,

--- a/internal/ctlog/s3.go
+++ b/internal/ctlog/s3.go
@@ -30,7 +30,7 @@ type S3Backend struct {
 	log           *slog.Logger
 }
 
-func NewS3Backend(ctx context.Context, region, bucket string, l *slog.Logger) (*S3Backend, error) {
+func NewS3Backend(ctx context.Context, region, bucket, endpoint string, l *slog.Logger) (*S3Backend, error) {
 	counter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "s3_requests_total",
@@ -92,7 +92,11 @@ func NewS3Backend(ctx context.Context, region, bucket string, l *slog.Logger) (*
 	}
 
 	return &S3Backend{
-		client: s3.NewFromConfig(cfg),
+		client: s3.NewFromConfig(cfg, func(o *s3.Options) {
+			if endpoint != "" {
+				o.BaseEndpoint = aws.String(endpoint)
+			}
+		}),
 		bucket: bucket,
 		metrics: []prometheus.Collector{counter, duration,
 			uploadSize, compressRatio, hedgeRequests, hedgeWins},


### PR DESCRIPTION
These are the two AWS services that Sunlight relies on.

Allowing them to be set enables using Sunlight in alternate environments without an AWS dependency, like in developer environments.