### PR TITLE
Add an option to prefix keys in S3

### DIFF
--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -142,6 +142,9 @@ type LogConfig struct {
 	S3Endpoint string
 
 	// S3KeyPrefix is a prefix on all keys written to S3. Optional.
+	//
+	// S3 doesn't have directories, but using a prefix ending in a "/" is
+	// going to be treated like a directory in many tools using S3.
 	S3KeyPrefix string
 
 	// NotAfterStart is the start of the validity range for certificates

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -141,6 +141,9 @@ type LogConfig struct {
 	// S3Endpoint is the base URL the AWS SDK will use to connect to S3. Optional.
 	S3Endpoint string
 
+	// S3KeyPrefix is a prefix on all keys written to S3. Optional.
+	S3KeyPrefix string
+
 	// NotAfterStart is the start of the validity range for certificates
 	// accepted by this log instance, as and RFC 3339 date.
 	NotAfterStart string
@@ -229,7 +232,7 @@ func main() {
 			slog.String("log", lc.ShortName),
 		}))
 
-		b, err := ctlog.NewS3Backend(ctx, lc.S3Region, lc.S3Bucket, lc.S3Endpoint, logger)
+		b, err := ctlog.NewS3Backend(ctx, lc.S3Region, lc.S3Bucket, lc.S3Endpoint, lc.S3KeyPrefix, logger)
 		if err != nil {
 			logger.Error("failed to create backend", "err", err)
 			os.Exit(1)

--- a/internal/ctlog/s3.go
+++ b/internal/ctlog/s3.go
@@ -143,7 +143,7 @@ func (s *S3Backend) Upload(ctx context.Context, key string, data []byte, opts *U
 			s.hedgeRequests.Inc()
 			_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 				Bucket:          aws.String(s.bucket),
-				Key:             aws.String(s.keyPrefix + "/" + key),
+				Key:             aws.String(s.keyPrefix + key),
 				Body:            bytes.NewReader(data),
 				ContentLength:   aws.Int64(int64(len(data))),
 				ContentEncoding: contentEncoding,
@@ -156,7 +156,7 @@ func (s *S3Backend) Upload(ctx context.Context, key string, data []byte, opts *U
 	}()
 	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:          aws.String(s.bucket),
-		Key:             aws.String(s.keyPrefix + "/" + key),
+		Key:             aws.String(s.keyPrefix + key),
 		Body:            bytes.NewReader(data),
 		ContentLength:   aws.Int64(int64(len(data))),
 		ContentEncoding: contentEncoding,
@@ -181,7 +181,7 @@ func (s *S3Backend) Upload(ctx context.Context, key string, data []byte, opts *U
 func (s *S3Backend) Fetch(ctx context.Context, key string) ([]byte, error) {
 	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(s.keyPrefix + "/" + key),
+		Key:    aws.String(s.keyPrefix + key),
 	})
 	if err != nil {
 		s.log.DebugContext(ctx, "S3 GET", "key", key, "err", err)


### PR DESCRIPTION
We'd like this to be able to expose multiple log shards on the same CDN configuration.

It could potentially be used to store multiple shards in the same bucket.