### PR TITLE
fix: address issues of sqlite backend

### DIFF
--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -80,7 +80,7 @@ type Config struct {
 	// The database must already exist to protect against accidental
 	// misconfiguration. Create the table with:
 	//
-	//     $ sqlite3 checkpoints.db "CREATE TABLE checkpoints (logID BLOB PRIMARY KEY, checkpoint TEXT)"
+	//     $ sqlite3 checkpoints.db "CREATE TABLE checkpoints (logID BLOB PRIMARY KEY, body TEXT)"
 	//
 	Checkpoints string
 


### PR DESCRIPTION
Using sqlite to save checkpoints failed at runtime because:

- Internal Mutex was a nil pointer
- The help messages explaining how to create the sqlite3 database had the wrong CREATE statement
- The implementation of the `LockBackend` interface had the `Fetch` function return a wrong object (a `dynamoCheckpoint` instead of a `sqliteCheckpoint`)
