### PR TITLE
feat: local backend

### DIFF
--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -80,7 +80,7 @@ type Config struct {
 	// The database must already exist to protect against accidental
 	// misconfiguration. Create the table with:
 	//
-	//     $ sqlite3 checkpoints.db "CREATE TABLE checkpoints (logID BLOB PRIMARY KEY, checkpoint TEXT)"
+	//     $ sqlite3 checkpoints.db "CREATE TABLE checkpoints (logID BLOB PRIMARY KEY, body TEXT)"
 	//
 	Checkpoints string
 

--- a/internal/ctlog/local.go
+++ b/internal/ctlog/local.go
@@ -1,0 +1,80 @@
+package ctlog
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// LocalFilesystemBackend is a backend that stores key-value pairs in the
+// local filesystem.
+// The keys are base64-encoded and the values are stored in files named after
+// the base64-encoded key.
+//
+// This is not meant to be used in production, but rather for testing and
+// development purposes.
+type LocalFilesystemBackend struct {
+	mu       *sync.RWMutex
+	rootPath string
+}
+
+func NewLocalBackend(path string) (*LocalFilesystemBackend, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			if err = os.MkdirAll(path, 0755); err != nil {
+				return nil, fmt.Errorf("failed to create directory %s: %w", path, err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to check if directory %s exists: %w", path, err)
+		}
+	}
+
+	return &LocalFilesystemBackend{
+		mu:       &sync.RWMutex{},
+		rootPath: path,
+	}, nil
+}
+
+// Upload saves the data associated to the key in the local filesystem.
+// Note well: upload options are not handled
+func (b *LocalFilesystemBackend) Upload(ctx context.Context, key string, data []byte, opts *UploadOptions) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	filename := keyToFilename(b.rootPath, key)
+	f, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to save key %s to file %s: %w", key, filename, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("failed to write contents of key %s to file %s: %w", key, filename, err)
+	}
+	return nil
+}
+
+func (b *LocalFilesystemBackend) Fetch(ctx context.Context, key string) ([]byte, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	filename := keyToFilename(b.rootPath, key)
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to read contents of file %s associated to key %s: %w", filename, key, err)
+	}
+
+	return data, nil
+}
+
+func (b *LocalFilesystemBackend) Metrics() []prometheus.Collector {
+	return []prometheus.Collector{}
+}
+
+func keyToFilename(rootPath, key string) string {
+	return path.Join(rootPath, base64.StdEncoding.EncodeToString([]byte(key)))
+}


### PR DESCRIPTION
> **Note:** this PR builds on top of https://github.com/FiloSottile/sunlight/pull/19

I really love how easy it is to sunlight for testing/playing purposes. I've noticed however that sunlight requires access to a S3-compatible server to store the logs data. I've added the possibility to the local filesystem instead of relying on a S3 bucket.
This is not meant to be used in production, it just simplifies the setup for testing purposes.

I hope you like this change. Thanks again for the great tool!

Just for reference, this is the configuration file I used to spin up a local testing instance:

```yaml
listen: ":8080"

checkpoints: checkpoints.db

logs:
  - name: sunlight.127.0.0.1.sslip.io/2024h1
    shortname: bergamo2024h1
    inception: 2024-06-28
    httpprefix: /2024h1
    roots: ./chain.pem
    key: ./key.pem
    cache: bergamo2024h1.db
    poolsize: 750
    notafterstart: 2024-06-26T00:00:00Z
    notafterlimit: 2024-07-01T00:00:00Z
    localbackend: local_backend
```
