### PR TITLE
Config: allow log pubkey to be provided as a filepath

### DIFF
--- a/cmd/partial-aftersun/main.go
+++ b/cmd/partial-aftersun/main.go
@@ -35,6 +35,9 @@ type LogConfig struct {
 	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded.
 	PublicKey string
 
+	// PublicKeyFile is a path to a file containing a pubkey as described above.
+	PublicKeyFile string
+
 	// LocalDirectory is the path to a local directory where the log will store
 	// its data. It must be dedicated to this specific log instance.
 	LocalDirectory string
@@ -223,7 +226,15 @@ func overrideImmutable(root *os.Root, name string) error {
 }
 
 func logSize(root *os.Root, log *LogConfig) (int64, error) {
-	cfgPubKey, err := base64.StdEncoding.DecodeString(log.PublicKey)
+	b64PubKey := log.PublicKey
+	if b64PubKey == "" {
+		pubKeyFile, err := os.ReadFile(log.PublicKeyFile)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read public key file: %w", err)
+		}
+		b64PubKey = string(pubKeyFile)
+	}
+	cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse public key base64: %w", err)
 	}

--- a/cmd/partial-aftersun/main.go
+++ b/cmd/partial-aftersun/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -33,8 +34,14 @@ type LogConfig struct {
 	// ShortName is the short name for the log, used as a metrics and logs label.
 	ShortName string
 
+	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded. If
+	// both PublicKey and PublicKeyFile are provided, the PublicKeyFile config
+	// value takes precedence.
+	PublicKey string
+
 	// PublicKeyFile is a path to a file containing the PEM-encoded Public Key
-	// for this log.
+	// for this log. If both PublicKey and PublicKeyFile are provided, this
+	// config value takes precedence.
 	PublicKeyFile string
 
 	// LocalDirectory is the path to a local directory where the log will store
@@ -225,15 +232,25 @@ func overrideImmutable(root *os.Root, name string) error {
 }
 
 func logSize(root *os.Root, log *LogConfig) (int64, error) {
-	pubKeyPEM, err := os.ReadFile(log.PublicKeyFile)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read public key file: %w", err)
+	var pubKeyDER []byte
+	if log.PublicKeyFile != "" {
+		pubKeyFile, err := os.ReadFile(log.PublicKeyFile)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read public key file: %w", err)
+		}
+		pubKeyPEM, _ := pem.Decode(pubKeyFile)
+		if pubKeyPEM == nil {
+			return 0, errors.New("failed to decode public key PEM")
+		}
+		pubKeyDER = pubKeyPEM.Bytes
+	} else {
+		cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse public key base64: %w", err)
+		}
+		pubKeyDER = cfgPubKey
 	}
-	pubKeyDER, _ := pem.Decode(pubKeyPEM)
-	if pubKeyDER == nil {
-		return 0, errors.New("failed to decode public key PEM")
-	}
-	pubKey, err := x509.ParsePKIXPublicKey(pubKeyDER.Bytes)
+	pubKey, err := x509.ParsePKIXPublicKey(pubKeyDER)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse public key: %w", err)
 	}

--- a/cmd/partial-aftersun/main.go
+++ b/cmd/partial-aftersun/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -34,14 +33,8 @@ type LogConfig struct {
 	// ShortName is the short name for the log, used as a metrics and logs label.
 	ShortName string
 
-	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded. If
-	// both PublicKey and PublicKeyFile are provided, the PublicKeyFile config
-	// value takes precedence.
-	PublicKey string
-
 	// PublicKeyFile is a path to a file containing the PEM-encoded Public Key
-	// for this log. If both PublicKey and PublicKeyFile are provided, this
-	// config value takes precedence.
+	// for this log.
 	PublicKeyFile string
 
 	// LocalDirectory is the path to a local directory where the log will store
@@ -232,25 +225,15 @@ func overrideImmutable(root *os.Root, name string) error {
 }
 
 func logSize(root *os.Root, log *LogConfig) (int64, error) {
-	var pubKeyDER []byte
-	if log.PublicKeyFile != "" {
-		pubKeyFile, err := os.ReadFile(log.PublicKeyFile)
-		if err != nil {
-			return 0, fmt.Errorf("failed to read public key file: %w", err)
-		}
-		pubKeyPEM, _ := pem.Decode(pubKeyFile)
-		if pubKeyPEM == nil {
-			return 0, errors.New("failed to decode public key PEM")
-		}
-		pubKeyDER = pubKeyPEM.Bytes
-	} else {
-		cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse public key base64: %w", err)
-		}
-		pubKeyDER = cfgPubKey
+	pubKeyPEM, err := os.ReadFile(log.PublicKeyFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read public key file: %w", err)
 	}
-	pubKey, err := x509.ParsePKIXPublicKey(pubKeyDER)
+	pubKeyDER, _ := pem.Decode(pubKeyPEM)
+	if pubKeyDER == nil {
+		return 0, errors.New("failed to decode public key PEM")
+	}
+	pubKey, err := x509.ParsePKIXPublicKey(pubKeyDER.Bytes)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse public key: %w", err)
 	}

--- a/cmd/partial-aftersun/main.go
+++ b/cmd/partial-aftersun/main.go
@@ -244,7 +244,7 @@ func logSize(root *os.Root, log *LogConfig) (int64, error) {
 		}
 		pubKeyDER = pubKeyPEM.Bytes
 	} else {
-		cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
+		cfgPubKey, err := base64.StdEncoding.DecodeString(log.PublicKey)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse public key base64: %w", err)
 		}

--- a/cmd/sunlight-keygen/keygen.go
+++ b/cmd/sunlight-keygen/keygen.go
@@ -20,7 +20,6 @@ import (
 
 func main() {
 	fs := flag.NewFlagSet("keygen", flag.ExitOnError)
-	pemOut := fs.Bool("pem", false, "output keys in PEM format")
 	fs.Parse(os.Args[1:])
 
 	if fs.NArg() != 2 {
@@ -48,10 +47,7 @@ func main() {
 
 	logID := sha256.Sum256(spki)
 
-	ecPubKey := base64.StdEncoding.EncodeToString(spki)
-	if *pemOut {
-		ecPubKey = "\n" + string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: spki}))
-	}
+	ecPubKey := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: spki}))
 
 	ed25519Secret := make([]byte, ed25519.SeedSize)
 	if _, err := io.ReadFull(hkdf.New(sha256.New, seed, []byte("sunlight"), []byte("Ed25519 log key")), ed25519Secret); err != nil {
@@ -59,10 +55,7 @@ func main() {
 	}
 	wk := ed25519.NewKeyFromSeed(ed25519Secret).Public().(ed25519.PublicKey)
 
-	edPubKey := base64.StdEncoding.EncodeToString(wk)
-	if *pemOut {
-		edPubKey = "\n" + string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: wk}))
-	}
+	edPubKey := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: wk}))
 
 	v, err := note.NewEd25519VerifierKey(fs.Arg(0), wk)
 	if err != nil {
@@ -70,7 +63,7 @@ func main() {
 	}
 
 	fmt.Printf("Log ID: %s\n", base64.StdEncoding.EncodeToString(logID[:]))
-	fmt.Printf("ECDSA public key: %s\n", ecPubKey)
-	fmt.Printf("Ed25519 public key: %s\n", edPubKey)
+	fmt.Printf("ECDSA public key:\n%s\n", ecPubKey)
+	fmt.Printf("Ed25519 public key:\n%s\n", edPubKey)
 	fmt.Printf("Witness verifier key: %s\n", v)
 }

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -171,12 +171,25 @@ type LogConfig struct {
 	//
 	Seed string
 
-	// PublicKeyFile is a path to a file containing the PEM-encoded Public Key
-	// for this log.
+	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded; this
+	// is the same format as used in Google and Apple's log list JSON files. If
+	// both PublicKey and PublicKeyFile are provided, the PublicKeyFile config
+	// value takes precedence.
 	//
 	// To generate this from a seed, run:
 	//
-	//   $ sunlight-keygen -pem log.example/logA seed.bin
+	//   $ sunlight-keygen log.example/logA seed.bin
+	//
+	// The loaded private Key is required to match it.
+	PublicKey string
+
+	// PublicKeyFile is a path to a file containing the PEM-encoded Public Key
+	// for this log. If both PublicKey and PublicKeyFile are provided, this
+	// config value takes precedence.
+	//
+	// To generate this from a seed, run:
+	//
+	//   $ sunlight-keygen log.example/logA seed.bin
 	//
 	// The loaded private key is required to match it.
 	PublicKeyFile string
@@ -403,15 +416,25 @@ func main() {
 		}
 		wk := ed25519.NewKeyFromSeed(ed25519Secret)
 
-		pubKeyPEM, err := os.ReadFile(lc.PublicKeyFile)
-		if err != nil {
-			fatalError(logger, "failed to read public key file", "err", err)
+		var pubKeyDER []byte
+		if lc.PublicKeyFile == "" {
+			pubKeyFile, err := os.ReadFile(lc.PublicKeyFile)
+			if err != nil {
+				fatalError(logger, "failed to read public key file", "err", err)
+			}
+			pubKeyPEM, _ := pem.Decode(pubKeyFile)
+			if pubKeyPEM == nil {
+				fatalError(logger, "failed to decode public key PEM", "err", err)
+			}
+			pubKeyDER = pubKeyPEM.Bytes
+		} else {
+			cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
+			if err != nil {
+				fatalError(logger, "failed to parse public key base64", "err", err)
+			}
+			pubKeyDER = cfgPubKey
 		}
-		pubKeyDER, _ := pem.Decode(pubKeyPEM)
-		if pubKeyDER == nil {
-			fatalError(logger, "failed to decode public key PEM", "err", err)
-		}
-		parsedPubKey, err := x509.ParsePKIXPublicKey(pubKeyDER.Bytes)
+		parsedPubKey, err := x509.ParsePKIXPublicKey(pubKeyDER)
 		if err != nil {
 			fatalError(logger, "failed to parse public key", "err", err)
 		}

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -417,7 +417,7 @@ func main() {
 		wk := ed25519.NewKeyFromSeed(ed25519Secret)
 
 		var pubKeyDER []byte
-		if lc.PublicKeyFile == "" {
+		if lc.PublicKeyFile != "" {
 			pubKeyFile, err := os.ReadFile(lc.PublicKeyFile)
 			if err != nil {
 				fatalError(logger, "failed to read public key file", "err", err)
@@ -428,7 +428,7 @@ func main() {
 			}
 			pubKeyDER = pubKeyPEM.Bytes
 		} else {
-			cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
+			cfgPubKey, err := base64.StdEncoding.DecodeString(lc.PublicKey)
 			if err != nil {
 				fatalError(logger, "failed to parse public key base64", "err", err)
 			}

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -189,7 +189,7 @@ type LogConfig struct {
 	//
 	// To generate this from a seed, run:
 	//
-	//   $ sunlight-keygen --pem log.example/logA seed.bin
+	//   $ sunlight-keygen -pem log.example/logA seed.bin
 	//
 	// The loaded private key is required to match it.
 	PublicKeyFile string

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -182,6 +182,11 @@ type LogConfig struct {
 	// The loaded private Key is required to match it.
 	PublicKey string
 
+	// PublicKeyFile is a path to a file containing a public key formatted in
+	// the same way as PublicKey above. If both config keys are present,
+	// PublicKey takes precedence.
+	PublicKeyFile string
+
 	// Cache is the path to the SQLite deduplication cache file.
 	Cache string
 
@@ -404,7 +409,15 @@ func main() {
 		}
 		wk := ed25519.NewKeyFromSeed(ed25519Secret)
 
-		cfgPubKey, err := base64.StdEncoding.DecodeString(lc.PublicKey)
+		b64PubKey := lc.PublicKey
+		if b64PubKey == "" {
+			pubKeyFile, err := os.ReadFile(lc.PublicKeyFile)
+			if err != nil {
+				fatalError(logger, "failed to read public key file", "err", err)
+			}
+			b64PubKey = string(pubKeyFile)
+		}
+		cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
 		if err != nil {
 			fatalError(logger, "failed to parse public key base64", "err", err)
 		}

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -171,21 +171,8 @@ type LogConfig struct {
 	//
 	Seed string
 
-	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded; this
-	// is the same format as used in Google and Apple's log list JSON files. If
-	// both PublicKey and PublicKeyFile are provided, the PublicKeyFile config
-	// value takes precedence.
-	//
-	// To generate this from a seed, run:
-	//
-	//   $ sunlight-keygen log.example/logA seed.bin
-	//
-	// The loaded private Key is required to match it.
-	PublicKey string
-
 	// PublicKeyFile is a path to a file containing the PEM-encoded Public Key
-	// for this log. If both PublicKey and PublicKeyFile are provided, this
-	// config value takes precedence.
+	// for this log.
 	//
 	// To generate this from a seed, run:
 	//
@@ -416,25 +403,15 @@ func main() {
 		}
 		wk := ed25519.NewKeyFromSeed(ed25519Secret)
 
-		var pubKeyDER []byte
-		if lc.PublicKeyFile == "" {
-			pubKeyFile, err := os.ReadFile(lc.PublicKeyFile)
-			if err != nil {
-				fatalError(logger, "failed to read public key file", "err", err)
-			}
-			pubKeyPEM, _ := pem.Decode(pubKeyFile)
-			if pubKeyPEM == nil {
-				fatalError(logger, "failed to decode public key PEM", "err", err)
-			}
-			pubKeyDER = pubKeyPEM.Bytes
-		} else {
-			cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
-			if err != nil {
-				fatalError(logger, "failed to parse public key base64", "err", err)
-			}
-			pubKeyDER = cfgPubKey
+		pubKeyPEM, err := os.ReadFile(lc.PublicKeyFile)
+		if err != nil {
+			fatalError(logger, "failed to read public key file", "err", err)
 		}
-		parsedPubKey, err := x509.ParsePKIXPublicKey(pubKeyDER)
+		pubKeyDER, _ := pem.Decode(pubKeyPEM)
+		if pubKeyDER == nil {
+			fatalError(logger, "failed to decode public key PEM", "err", err)
+		}
+		parsedPubKey, err := x509.ParsePKIXPublicKey(pubKeyDER.Bytes)
 		if err != nil {
 			fatalError(logger, "failed to parse public key", "err", err)
 		}

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -171,9 +171,10 @@ type LogConfig struct {
 	//
 	Seed string
 
-	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded.
-	//
-	// This is the same format as used in Google and Apple's log list JSON files.
+	// PublicKey is the SubjectPublicKeyInfo for this log, base64 encoded; this
+	// is the same format as used in Google and Apple's log list JSON files. If
+	// both PublicKey and PublicKeyFile are provided, the PublicKeyFile config
+	// value takes precedence.
 	//
 	// To generate this from a seed, run:
 	//
@@ -182,9 +183,15 @@ type LogConfig struct {
 	// The loaded private Key is required to match it.
 	PublicKey string
 
-	// PublicKeyFile is a path to a file containing a public key formatted in
-	// the same way as PublicKey above. If both config keys are present,
-	// PublicKey takes precedence.
+	// PublicKeyFile is a path to a file containing the PEM-encoded Public Key
+	// for this log. If both PublicKey and PublicKeyFile are provided, this
+	// config value takes precedence.
+	//
+	// To generate this from a seed, run:
+	//
+	//   $ sunlight-keygen --pem log.example/logA seed.bin
+	//
+	// The loaded private key is required to match it.
 	PublicKeyFile string
 
 	// Cache is the path to the SQLite deduplication cache file.
@@ -409,19 +416,25 @@ func main() {
 		}
 		wk := ed25519.NewKeyFromSeed(ed25519Secret)
 
-		b64PubKey := lc.PublicKey
-		if b64PubKey == "" {
+		var pubKeyDER []byte
+		if lc.PublicKeyFile == "" {
 			pubKeyFile, err := os.ReadFile(lc.PublicKeyFile)
 			if err != nil {
 				fatalError(logger, "failed to read public key file", "err", err)
 			}
-			b64PubKey = string(pubKeyFile)
+			pubKeyPEM, _ := pem.Decode(pubKeyFile)
+			if pubKeyPEM == nil {
+				fatalError(logger, "failed to decode public key PEM", "err", err)
+			}
+			pubKeyDER = pubKeyPEM.Bytes
+		} else {
+			cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
+			if err != nil {
+				fatalError(logger, "failed to parse public key base64", "err", err)
+			}
+			pubKeyDER = cfgPubKey
 		}
-		cfgPubKey, err := base64.StdEncoding.DecodeString(b64PubKey)
-		if err != nil {
-			fatalError(logger, "failed to parse public key base64", "err", err)
-		}
-		parsedPubKey, err := x509.ParsePKIXPublicKey(cfgPubKey)
+		parsedPubKey, err := x509.ParsePKIXPublicKey(pubKeyDER)
 		if err != nil {
 			fatalError(logger, "failed to parse public key", "err", err)
 		}


### PR DESCRIPTION
Add a new PublicKeyFile config item to sunlight and partial-aftersun. This behaves the same as the existing PublicKey config item, except that it expects to read the base64-encoded key from the indicated file rather than embedding the key within the config file directly.

Allowing the public key to be loaded from a file means that a single orchestration system can be responsible for laying down the seed file, the pubkey file, and the config file all in parallel. This is an improvement over the status quo, where the seed must be generated before the public key can be baked into the config file.

A follow-up PR can remove the original PublicKey config item, if desired.