### PR TITLE
Minor documentation additions

### DIFF
--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -79,8 +79,8 @@ type Config struct {
 		Directory string
 	}
 
-	// Checkpoints, ETagS3, or DynamoDB store the latest checkpoint for each
-	// log, with compare-and-swap semantics.
+	// Checkpoints, ETagS3, or DynamoDB configure the global lock backend, which
+	// stores the latest checkpoint for each log, with compare-and-swap semantics.
 	//
 	// Note that these are global as an extra safety measure: entries are keyed
 	// by log ID (the hash of the public key), so even in case of

--- a/cmd/sunlight/main.go
+++ b/cmd/sunlight/main.go
@@ -235,7 +235,8 @@ type LogConfig struct {
 	// The loaded private key is required to match it.
 	PublicKeyFile string
 
-	// Cache is the path to the SQLite deduplication cache file.
+	// Cache is the path to the SQLite deduplication cache file. It will be
+	// created if it doesn't already exist.
 	Cache string
 
 	// PoolSize is the maximum number of chains pending in the sequencing pool.
@@ -261,7 +262,8 @@ type LogConfig struct {
 	S3KeyPrefix string
 
 	// LocalDirectory is the path to a local directory where the log will store
-	// its data. It must be dedicated to this specific log instance.
+	// its data. It must be dedicated to this specific log instance. The directory
+	// must already exist.
 	//
 	// Only one of S3Bucket or LocalDirectory can be set at the same time.
 	LocalDirectory string


### PR DESCRIPTION
When setting up Sunlight, I found it a bit confusing that some local paths were created automatically while others I needed to create ahead-of-time.