### PR TITLE
internal/witness: return 404 for unknown log, matching the spec

### DIFF
--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -301,7 +301,10 @@ func (w *Witness) serveAddCheckpoint(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	switch err {
-	case errUnknownLog, errInvalidSignature:
+	case errUnknownLog:
+		http.Error(rw, err.Error(), http.StatusNotFound)
+		return
+	case errInvalidSignature:
 		http.Error(rw, err.Error(), http.StatusForbidden)
 		return
 	case errBadRequest:


### PR DESCRIPTION
## Summary

c2sp.org/tlog-witness says the witness MUST respond with "404 Not Found" when the checkpoint origin is unknown. `serveAddCheckpoint` currently collapses `errUnknownLog` and `errInvalidSignature` onto a single `StatusForbidden` (403) case, which diverges from the spec and from sigsum-go's [sigsum-witness][sigsum-ref], which returns 404 for an unknown origin and reserves 403 for "no trusted-key signature verifies".

Split the switch so `errUnknownLog` returns 404 while `errInvalidSignature` continues to return 403.

[sigsum-ref]: https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/cmd/sigsum-witness/sigsum-witness.go#L154-L161

## Context

Noticed while cross-checking the Cloudflare witness implementation ([azul PR #218][azul]) against sunlight and sigsum-go to resolve a separate spec ambiguity about invalid trusted-key signatures (see [C2SP PR][c2sp]). All three implementations agree on the 403/invalid-signature path, but only sunlight returns 403 for an unknown origin — the spec and sigsum-go both say 404.

[azul]: https://github.com/cloudflare/azul/pull/218
[c2sp]: https://github.com/C2SP/C2SP/pulls

## Testing

- `go build ./...` clean.
- `go test ./internal/witness/...` — no existing tests in the package.