### PR TITLE
Expose build version in prometheus metrics

### DIFF
--- a/cmd/sunlight/sunlight.go
+++ b/cmd/sunlight/sunlight.go
@@ -392,6 +392,25 @@ func main() {
 	}))
 	sunlightMetrics := prometheus.WrapRegistererWithPrefix("sunlight_", metrics)
 
+	buildInfo, _ := debug.ReadBuildInfo()
+	buildVersion := buildInfo.Main.Version
+	buildCommit := ""
+	for _, s := range buildInfo.Settings {
+		if s.Key == "vcs.revision" {
+			buildCommit = s.Value
+			break
+		}
+	}
+	buildInfoGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sunlight_build_info",
+			Help: "Build information about the running sunlight binary.",
+		},
+		[]string{"version", "commit"},
+	)
+	buildInfoGauge.WithLabelValues(buildVersion, buildCommit).Set(1)
+	metrics.MustRegister(buildInfoGauge)
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 


### PR DESCRIPTION
Here's examples of what the metric looks like:
```
$ curl -sk https://localhost:8080/metrics | grep '^sunlight_build'
sunlight_build_info{commit="4609173f5d638692944d5e66731fec856c9efdfc",version="v0.8.1-0.20260522193737-4609173f5d63+dirty"} 1
```

The `version=` information is documented [here](https://go.dev/ref/mod#pseudo-versions).