### PR TITLE
Allow changing the landing page title via config

### DIFF
--- a/cmd/sunlight/home.html
+++ b/cmd/sunlight/home.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>Sunlight</title>
+    <title>{{ .Title }}</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/cmd/sunlight/sunlight.go
+++ b/cmd/sunlight/sunlight.go
@@ -65,6 +65,10 @@ import (
 )
 
 type Config struct {
+	// Name is the display name for this Sunlight instance, used as the
+	// HTML page title. Optional. If empty, the title defaults to "Sunlight".
+	Name string
+
 	// Listen are the addresses to listen on, e.g. ":443".
 	Listen []string
 
@@ -466,10 +470,16 @@ func main() {
 	homeWitnessInfo := func() witnessInfo { return witnessInfo{} }
 	mux.HandleFunc("/{$}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
+		pageTitle := "Sunlight"
+		if c.Name != "" {
+			pageTitle = c.Name
+		}
 		if err := homeTmpl.Execute(w, struct {
+			Title   string
 			Logs    []logInfo
 			Witness witnessInfo
 		}{
+			Title:   pageTitle,
 			Logs:    homeLogsInfo(),
 			Witness: homeWitnessInfo(),
 		}); err != nil {


### PR DESCRIPTION
When I have many sunlight logs open in my browser, it's difficult to tell where I am at a glance. What are the odds that anyone actually needs this? Slim to none, but it would help me. 

Adds a new `name` config option to allow changing the landing page's page title. If unset, it'll default to `Sunlight` like all currently running logs have.

Example config:
```
$ cat config.yaml 
name: "Phil Log"
listen:
  - ":8080"

checkpoints: checkpoints.db

logs:
  - shortname: testlog
    submissionprefix: "https://localhost:8080/testlog"
    monitoringprefix: "https://localhost:8080/testlog"
    inception: "2026-05-22"
    notafterstart: "2026-01-01T00:00:00Z"
    notafterlimit: "2027-01-01T00:00:00Z"
    secret: seed.bin
    cache: cache.db
    localdirectory: ./data/testlog
```

<img width="972" height="82" alt="show-log-name" src="https://github.com/user-attachments/assets/4b3b4a64-1452-440a-a1da-774c3821c749" />
