### PR TITLE
Show Final tree info for sunset logs

### DIFF
--- a/cmd/sunlight/home.html
+++ b/cmd/sunlight/home.html
@@ -72,14 +72,21 @@
             download="{{ .ShortName }}.der">key</a>
         <a href="{{ .SubmissionPrefix }}ct/v1/get-roots">get-roots</a>
         <a href="{{ .SubmissionPrefix }}log.v3.json">json</a><br>
+      {{ if .FinalTree.Size }}
+      Final tree size: {{ .FinalTree.Size }} at {{ timestamp .FinalTree.Timestamp }}<br>
+      Final tree hash: {{ printf "%x" .FinalTree.RootHash }}
+      {{ else }}
       Ratelimit: {{ .PoolSize }} req/s
-    
+      {{ end }}
+
     <pre><code>{{ .PublicKeyPEM }}</code></pre>
-    
+
+    {{ if not .FinalTree.Size }}
     <h3>Submit a certificate chain (PEM or JSON)</h3>
       
     <input type="file" class="chain" data-prefix="{{ .SubmissionPrefix }}">
     <pre><code class="response"></code></pre>
+    {{ end }}
 
     {{ end }}
 

--- a/cmd/sunlight/sunlight.go
+++ b/cmd/sunlight/sunlight.go
@@ -346,7 +346,9 @@ type logInfo struct {
 
 //go:embed home.html
 var homeHTML string
-var homeTmpl = template.Must(template.New("home").Parse(homeHTML))
+var homeTmpl = template.Must(template.New("home").Funcs(template.FuncMap{
+	"timestamp": func(ms int64) string { return time.UnixMilli(ms).UTC().Format(time.RFC3339) },
+}).Parse(homeHTML))
 
 func main() {
 	fs := flag.NewFlagSet("sunlight", flag.ExitOnError)


### PR DESCRIPTION
If a tree has been sunset, show the size, timestamp, and hash.

Don't show the ratelimit or submit UI.
