### PR TITLE
Add mark certificate log profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,38 @@ Each six-months shard will reach approximately 1.5 TB at current rates. It start
 
 You should consider a separate ZFS dataset or object storage bucket for each log, to make it easier to delete it once the log is retired. See, for example, [the Tuscolo ZFS configuration](https://gist.github.com/FiloSottile/989338e6ba8e03f2c699590ce83f537b). However, note that using separate AWS S3 buckets can cause [dynamic scaling issues when traffic moves naturally from one to another](https://groups.google.com/a/chromium.org/g/ct-policy/c/0R43Z58JuzA/m/raeusYYqAAAJ), so you should use a single bucket and delete logs with lifecycle rules if hosting on AWS S3.
 
+### Accepted roots and certificate profiles
+
+By default, Sunlight operates as a TLS Certificate Transparency log. It fetches accepted roots from CCADB, accepts chains for certificates with the `serverAuth` EKU, and publishes `intended_use` in `log.v3.json` according to the configured CCADB root set.
+
+```yaml
+    ccadbroots: trusted # default if roots is not set
+```
+
+For logs with a custom accepted root set, use a PEM file. The file is loaded on startup and reloaded on SIGHUP, and its contents are uploaded to the storage backend as the log's accepted roots.
+
+```yaml
+    roots: /tank/logs/example2025h2/roots.pem
+```
+
+Sunlight can also operate a mark certificate CT log. Mark certificate logs are not TLS server authentication logs: they do not require the `serverAuth` EKU, and instead require the Verified Mark Certificate EKU (`1.3.6.1.5.5.7.3.31`) on submitted leaves. Mark logs intentionally omit `intended_use` from `log.v3.json` to avoid being classified as TLS production or test logs by consumers.
+
+```yaml
+    certificateprofile: mark
+    markrootsurl: https://example.org/ct/v1/get-roots
+```
+
+`markrootsurl` must point at an RFC 6962 `get-roots` endpoint. Sunlight fetches it on startup and every 15 minutes, and reloads it on SIGHUP. If the initial fetch fails and no cached roots exist in the storage backend, startup fails. After roots have been cached, refresh failures keep using the last-known-good root set. A successful refresh treats `markrootsurl` as the source of truth and replaces the persisted roots, including removals.
+
+Public mark certificate logs should usually rely on the VMC EKU plus accepted roots. For private or restricted deployments, `markcertificatepolicies` can require one or more certificate policy OIDs on submitted leaves.
+
+```yaml
+    certificateprofile: mark
+    markrootsurl: https://example.org/ct/v1/get-roots
+    markcertificatepolicies:
+      - 1.2.3.4
+```
+
 ### Hosting the read path
 
 The [Static CT monitoring API](https://github.com/C2SP/C2SP/blob/static-ct-api/v1.0.0/static-ct-api.md#monitoring-apis) can be implemented by simply serving the files uploaded to or stored in the storage backend by Sunlight.

--- a/cmd/sunlight/mark_roots_test.go
+++ b/cmd/sunlight/mark_roots_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"filippo.io/sunlight/internal/ctlog"
+)
+
+func TestFetchRFC6962Roots(t *testing.T) {
+	der := testRootDER(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.UserAgent() == "" {
+			t.Error("missing User-Agent")
+		}
+		if r.URL.Path != "/ct/v1/get-roots" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if err := json.NewEncoder(w).Encode(struct {
+			Certificates []string `json:"certificates"`
+		}{
+			Certificates: []string{base64.StdEncoding.EncodeToString(der)},
+		}); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	roots, err := FetchRFC6962Roots(context.Background(), ts.URL+"/ct/v1/get-roots")
+	if err != nil {
+		t.Fatalf("FetchRFC6962Roots returned error: %v", err)
+	}
+	if !strings.Contains(string(roots), "BEGIN CERTIFICATE") {
+		t.Fatalf("FetchRFC6962Roots did not return PEM: %q", roots)
+	}
+}
+
+func TestFetchRFC6962RootsRejectsEmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(struct {
+			Certificates []string `json:"certificates"`
+		}{}); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	if _, err := FetchRFC6962Roots(context.Background(), ts.URL); err == nil {
+		t.Fatal("FetchRFC6962Roots succeeded with no certificates")
+	}
+}
+
+func TestParseOID(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid", in: "1.3.6.1.5.5.7.3.31", want: "1.3.6.1.5.5.7.3.31"},
+		{name: "first arc 2 allows large second arc", in: "2.999.1", want: "2.999.1"},
+		{name: "empty arc", in: "1..3", wantErr: true},
+		{name: "too few arcs", in: "1", wantErr: true},
+		{name: "negative arc", in: "1.-1.3", wantErr: true},
+		{name: "invalid first arc", in: "3.1.1", wantErr: true},
+		{name: "invalid second arc", in: "1.40.1", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oid, err := parseOID(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseOID succeeded")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOID returned error: %v", err)
+			}
+			if got := oid.String(); got != tt.want {
+				t.Fatalf("got OID %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateLogConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		lc      LogConfig
+		profile string
+		wantErr bool
+	}{
+		{
+			name:    "TLS default with CCADB",
+			profile: ctlog.CertificateProfileTLS,
+		},
+		{
+			name:    "mark with roots file",
+			lc:      LogConfig{Roots: "roots.pem", CertificateProfile: ctlog.CertificateProfileMark},
+			profile: ctlog.CertificateProfileMark,
+		},
+		{
+			name:    "mark with roots URL",
+			lc:      LogConfig{MarkRootsURL: "https://example.com/ct/v1/get-roots", CertificateProfile: ctlog.CertificateProfileMark},
+			profile: ctlog.CertificateProfileMark,
+		},
+		{
+			name:    "mark requires root source",
+			lc:      LogConfig{CertificateProfile: ctlog.CertificateProfileMark},
+			profile: ctlog.CertificateProfileMark,
+			wantErr: true,
+		},
+		{
+			name:    "mark rejects CCADB",
+			lc:      LogConfig{CertificateProfile: ctlog.CertificateProfileMark, MarkRootsURL: "https://example.com/roots", CCADBRoots: "trusted"},
+			profile: ctlog.CertificateProfileMark,
+			wantErr: true,
+		},
+		{
+			name:    "TLS rejects mark URL",
+			lc:      LogConfig{MarkRootsURL: "https://example.com/roots"},
+			profile: ctlog.CertificateProfileTLS,
+			wantErr: true,
+		},
+		{
+			name:    "roots rejects extra roots",
+			lc:      LogConfig{Roots: "roots.pem", ExtraRoots: "extra.pem"},
+			profile: ctlog.CertificateProfileTLS,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLogConfig(tt.lc, tt.profile)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateLogConfig error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCertificateProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to TLS", want: ctlog.CertificateProfileTLS},
+		{name: "explicit TLS", in: ctlog.CertificateProfileTLS, want: ctlog.CertificateProfileTLS},
+		{name: "mark", in: ctlog.CertificateProfileMark, want: ctlog.CertificateProfileMark},
+		{name: "invalid", in: "email", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := certificateProfile(LogConfig{CertificateProfile: tt.in})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("certificateProfile succeeded")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("certificateProfile returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got profile %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func testRootDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Mark Root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	return der
+}

--- a/cmd/sunlight/roots.go
+++ b/cmd/sunlight/roots.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -27,6 +28,22 @@ func loadRoots(ctx context.Context, lc LogConfig, l *ctlog.Log) error {
 		return err
 	}
 	return nil
+}
+
+func loadMarkRoots(ctx context.Context, lc LogConfig, l *ctlog.Log) (newRoots bool, err error) {
+	rootsPEM, err := FetchRFC6962Roots(ctx, lc.MarkRootsURL)
+	if err != nil {
+		return false, err
+	}
+	if bytes.Equal(rootsPEM, l.RootsPEM()) {
+		return false, nil
+	}
+	// MarkRootsURL is treated as the source of truth, so a successful refresh
+	// replaces the persisted root set, including removals from the source.
+	if err := l.SetRootsFromPEM(ctx, rootsPEM); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func loadCCADBRoots(ctx context.Context, lc LogConfig, l *ctlog.Log) (newRoots bool, err error) {
@@ -91,6 +108,51 @@ func loadCCADBRoots(ctx context.Context, lc LogConfig, l *ctlog.Log) (newRoots b
 
 var CCADBClient = &http.Client{
 	Timeout: 10 * time.Second,
+}
+
+var RFC6962RootsClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+func FetchRFC6962Roots(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "+https://filippo.io/sunlight")
+	resp, err := RFC6962RootsClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RFC 6962 roots: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch RFC 6962 roots: %s", resp.Status)
+	}
+
+	var roots struct {
+		Certificates [][]byte `json:"certificates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&roots); err != nil {
+		return nil, fmt.Errorf("failed to parse RFC 6962 roots response: %w", err)
+	}
+	if len(roots.Certificates) == 0 {
+		return nil, fmt.Errorf("no certificates found in RFC 6962 roots response")
+	}
+	var buf bytes.Buffer
+	for _, der := range roots.Certificates {
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse RFC 6962 root certificate: %w", err)
+		}
+		fmt.Fprintf(&buf, "# %s\n%s\n",
+			cert.Subject.String(),
+			pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cert.Raw,
+			}),
+		)
+	}
+	return buf.Bytes(), nil
 }
 
 func CCADBRoots(ctx context.Context, url string) ([]*x509.Certificate, error) {

--- a/cmd/sunlight/sunlight.go
+++ b/cmd/sunlight/sunlight.go
@@ -28,6 +28,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"log/slog"
 	"maps"
@@ -39,6 +40,7 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -52,6 +54,7 @@ import (
 	"filippo.io/sunlight/internal/reused"
 	"filippo.io/sunlight/internal/stdlog"
 	"filippo.io/sunlight/internal/witness"
+	ctasn1 "github.com/google/certificate-transparency-go/asn1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -244,6 +247,21 @@ type LogConfig struct {
 	//
 	// Once added, roots are never removed for the lifespan of a log.
 	ExtraRoots string
+
+	// CertificateProfile controls certificate acceptance policy. It can be
+	// "tls" or "mark", and defaults to "tls".
+	CertificateProfile string
+
+	// MarkRootsURL is the RFC 6962 get-roots endpoint to use as the accepted
+	// roots source for mark certificate logs. The fetched roots are persisted
+	// to Backend and refreshed periodically and on SIGHUP.
+	MarkRootsURL string
+
+	// MarkCertificatePolicies is an optional list of certificate policy OIDs
+	// to require on mark certificate leaves. It is intended for private or
+	// restricted logs; public mark certificate logs should usually leave it
+	// empty and rely on the mark EKU plus accepted roots.
+	MarkCertificatePolicies []string
 
 	// Secret is the path to a file containing a secret seed from which the
 	// log's private keys are derived. The file contents are used as HKDF input.
@@ -636,6 +654,21 @@ func main() {
 			NotAfterStart: notAfterStart,
 			NotAfterLimit: notAfterLimit,
 		}
+		profile, err := certificateProfile(lc)
+		if err != nil {
+			fatalError(logger, "invalid CertificateProfile", "err", err)
+		}
+		if err := validateLogConfig(lc, profile); err != nil {
+			fatalError(logger, "invalid log config", "err", err)
+		}
+		cc.CertificateProfile = profile
+		for _, s := range lc.MarkCertificatePolicies {
+			oid, err := parseOID(s)
+			if err != nil {
+				fatalError(logger, "failed to parse MarkCertificatePolicies OID", "oid", s, "err", err)
+			}
+			cc.MarkCertificatePolicies = append(cc.MarkCertificatePolicies, oid)
+		}
 
 		if time.Now().Format(time.DateOnly) == lc.Inception {
 			logger.Info("today is the Inception date, creating log")
@@ -658,9 +691,6 @@ func main() {
 		reloadChan := make(chan os.Signal, 1)
 		signal.Notify(reloadChan, syscall.SIGHUP)
 		if lc.Roots != "" {
-			if lc.CCADBRoots != "" || lc.ExtraRoots != "" {
-				fatalError(logger, "can't set both Roots and CCADBRoots or ExtraRoots")
-			}
 			if err := loadRoots(ctx, lc, l); err != nil {
 				fatalError(logger, "failed to load Roots", "file", lc.Roots, "err", err)
 			}
@@ -676,6 +706,35 @@ func main() {
 						continue
 					}
 					logger.Info("successfully reloaded roots on SIGHUP", "file", lc.Roots)
+				}
+			})
+		} else if lc.MarkRootsURL != "" {
+			if newRoots, err := loadMarkRoots(ctx, lc, l); err != nil {
+				if len(l.RootsPEM()) == 0 {
+					fatalError(logger, "failed to load initial mark roots and no cached roots exist",
+						"url", lc.MarkRootsURL, "err", err)
+				}
+				logger.Error("failed to load initial mark roots, using cached roots",
+					"url", lc.MarkRootsURL, "err", err)
+			} else if newRoots {
+				logger.Info("successfully loaded mark roots", "url", lc.MarkRootsURL)
+			}
+			serveGroup.Go(func() error {
+				ticker := time.NewTicker(15 * time.Minute)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-reloadChan:
+					case <-ticker.C:
+					}
+					if newRoots, err := loadMarkRoots(ctx, lc, l); err != nil {
+						logger.Error("failed to reload mark roots, keeping cached roots",
+							"url", lc.MarkRootsURL, "err", err)
+					} else if newRoots {
+						logger.Info("successfully reloaded mark roots", "url", lc.MarkRootsURL)
+					}
 				}
 			})
 		} else {
@@ -955,6 +1014,8 @@ func updateMetadata(ctx context.Context, setLogInfo func(string, logInfo), lc Lo
 	log.SubmissionEndpoint.URL = log.SubmissionPrefix
 	log.MonitoringEndpoint.URL = log.MonitoringPrefix
 	switch {
+	case cc.CertificateProfile == ctlog.CertificateProfileMark:
+		// No IntendedUse for mark certificate logs.
 	case lc.Roots != "":
 		// No IntendedUse for custom roots.
 	case lc.CCADBRoots == "trusted" || lc.CCADBRoots == "":
@@ -988,6 +1049,68 @@ func updateMetadata(ctx context.Context, setLogInfo func(string, logInfo), lc Lo
 		return err
 	}
 	return cc.Backend.Upload(ctx, "log.v3.json", j, &ctlog.UploadOptions{ContentType: "application/json"})
+}
+
+func certificateProfile(lc LogConfig) (string, error) {
+	switch lc.CertificateProfile {
+	case "", ctlog.CertificateProfileTLS:
+		return ctlog.CertificateProfileTLS, nil
+	case ctlog.CertificateProfileMark:
+		return ctlog.CertificateProfileMark, nil
+	default:
+		return "", fmt.Errorf("CertificateProfile must be %q, %q, or empty", ctlog.CertificateProfileTLS, ctlog.CertificateProfileMark)
+	}
+}
+
+func validateLogConfig(lc LogConfig, profile string) error {
+	if profile != ctlog.CertificateProfileMark && (lc.MarkRootsURL != "" || len(lc.MarkCertificatePolicies) != 0) {
+		return fmt.Errorf("MarkRootsURL and MarkCertificatePolicies require CertificateProfile %q", ctlog.CertificateProfileMark)
+	}
+	if profile == ctlog.CertificateProfileMark {
+		if lc.CCADBRoots != "" || lc.ExtraRoots != "" {
+			return fmt.Errorf("CCADBRoots and ExtraRoots are not supported with CertificateProfile %q", ctlog.CertificateProfileMark)
+		}
+		if (lc.Roots == "") == (lc.MarkRootsURL == "") {
+			return fmt.Errorf("CertificateProfile %q requires exactly one of Roots or MarkRootsURL", ctlog.CertificateProfileMark)
+		}
+	}
+	if lc.Roots != "" {
+		if lc.CCADBRoots != "" || lc.ExtraRoots != "" {
+			return fmt.Errorf("can't set both Roots and CCADBRoots or ExtraRoots")
+		}
+		if lc.MarkRootsURL != "" {
+			return fmt.Errorf("can't set both Roots and MarkRootsURL")
+		}
+	}
+	return nil
+}
+
+func parseOID(s string) (ctasn1.ObjectIdentifier, error) {
+	parts := strings.Split(s, ".")
+	oid := make(ctasn1.ObjectIdentifier, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("empty OID arc")
+		}
+		arc, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, err
+		}
+		if arc < 0 {
+			return nil, fmt.Errorf("negative OID arc %d", arc)
+		}
+		oid = append(oid, arc)
+	}
+	if len(oid) < 2 {
+		return nil, fmt.Errorf("OID must contain at least two arcs")
+	}
+	if oid[0] > 2 {
+		return nil, fmt.Errorf("first OID arc must be 0, 1, or 2")
+	}
+	if oid[0] < 2 && oid[1] > 39 {
+		return nil, fmt.Errorf("second OID arc must be no more than 39 when first arc is %d", oid[0])
+	}
+	return oid, nil
 }
 
 func fetchCheckpoint(ctx context.Context, logger *slog.Logger, prefix string) []byte {

--- a/internal/ctlog/ctlog.go
+++ b/internal/ctlog/ctlog.go
@@ -28,6 +28,7 @@ import (
 	"crawshaw.io/sqlite"
 	"filippo.io/sunlight"
 	ct "github.com/google/certificate-transparency-go"
+	ctasn1 "github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/cryptobyte"
@@ -107,7 +108,15 @@ type Config struct {
 
 	NotAfterStart time.Time
 	NotAfterLimit time.Time
+
+	CertificateProfile      string
+	MarkCertificatePolicies []ctasn1.ObjectIdentifier
 }
+
+const (
+	CertificateProfileTLS  = "tls"
+	CertificateProfileMark = "mark"
+)
 
 var ErrLogExists = errors.New("checkpoint already exist, refusing to initialize log")
 

--- a/internal/ctlog/http.go
+++ b/internal/ctlog/http.go
@@ -15,6 +15,7 @@ import (
 	"filippo.io/sunlight"
 	"filippo.io/sunlight/internal/reused"
 	ct "github.com/google/certificate-transparency-go"
+	ctasn1 "github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
@@ -143,8 +144,11 @@ func (l *Log) addChainOrPreChain(ctx context.Context, reqBody io.ReadCloser, che
 		return nil, http.StatusBadRequest, fmtErrorf("empty chain")
 	}
 
-	chain, err := ctfe.ValidateChain(req.Chain, ctfe.NewCertValidationOpts(l.rootPool(), time.Time{}, false, false, &l.c.NotAfterStart, &l.c.NotAfterLimit, false, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}))
+	chain, err := ctfe.ValidateChain(req.Chain, l.certValidationOpts())
 	if err != nil {
+		return nil, http.StatusBadRequest, fmtErrorf("invalid chain: %w", err)
+	}
+	if err := l.validateCertificateProfile(chain[0]); err != nil {
 		return nil, http.StatusBadRequest, fmtErrorf("invalid chain: %w", err)
 	}
 	lowPriority := lowPriority(chain[0])
@@ -252,6 +256,50 @@ func lowPriority(c *x509.Certificate) bool {
 	// verify the signatures, but this check is meant for when we are under load
 	// and need to prioritize.
 	return len(c.SCTList.SCTList) > 0
+}
+
+func (l *Log) certValidationOpts() ctfe.CertValidationOpts {
+	var extKeyUsages []x509.ExtKeyUsage
+	if l.c.CertificateProfile == "" || l.c.CertificateProfile == CertificateProfileTLS {
+		extKeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+	return ctfe.NewCertValidationOpts(l.rootPool(), time.Time{}, false, false,
+		&l.c.NotAfterStart, &l.c.NotAfterLimit, false, extKeyUsages)
+}
+
+var markCertificateEKU = ctasn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 31}
+
+func (l *Log) validateCertificateProfile(leaf *x509.Certificate) error {
+	if l.c.CertificateProfile != CertificateProfileMark {
+		return nil
+	}
+	if !hasUnknownExtKeyUsage(leaf, markCertificateEKU) {
+		return fmt.Errorf("rejecting certificate without mark certificate EKU %s", markCertificateEKU.String())
+	}
+	for _, policy := range l.c.MarkCertificatePolicies {
+		if !hasCertificatePolicy(leaf, policy) {
+			return fmt.Errorf("rejecting certificate without certificate policy %s", policy.String())
+		}
+	}
+	return nil
+}
+
+func hasUnknownExtKeyUsage(cert *x509.Certificate, oid ctasn1.ObjectIdentifier) bool {
+	for _, eku := range cert.UnknownExtKeyUsage {
+		if eku.Equal(oid) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCertificatePolicy(cert *x509.Certificate, oid ctasn1.ObjectIdentifier) bool {
+	for _, policy := range cert.PolicyIdentifiers {
+		if policy.Equal(oid) {
+			return true
+		}
+	}
+	return false
 }
 
 func (l *Log) getRoots(rw http.ResponseWriter, r *http.Request) {

--- a/internal/ctlog/mark_submit_test.go
+++ b/internal/ctlog/mark_submit_test.go
@@ -1,0 +1,125 @@
+package ctlog_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"filippo.io/sunlight/internal/ctlog"
+	ct "github.com/google/certificate-transparency-go"
+	ctasn1 "github.com/google/certificate-transparency-go/asn1"
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/certificate-transparency-go/x509/pkix"
+)
+
+var testMarkCertificateEKU = ctasn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 31}
+
+func TestSubmitCertificateProfiles(t *testing.T) {
+	requiredPolicy := ctasn1.ObjectIdentifier{2, 16, 840, 1, 114413, 1, 7, 23, 4}
+
+	t.Run("mark accepts mark EKU", func(t *testing.T) {
+		tl := NewEmptyTestLog(t)
+		tl.Config.CertificateProfile = ctlog.CertificateProfileMark
+		chain := newTestChain(t, nil, []ctasn1.ObjectIdentifier{testMarkCertificateEKU}, nil)
+		setTestRoots(t, tl, chain.root)
+
+		if _, err := tl.LogClient().AddChain(context.Background(), []ct.ASN1Cert{
+			{Data: chain.leaf}, {Data: chain.root},
+		}); err != nil {
+			t.Fatalf("AddChain returned error: %v", err)
+		}
+	})
+
+	t.Run("mark rejects serverAuth without mark EKU", func(t *testing.T) {
+		tl := NewEmptyTestLog(t)
+		tl.Config.CertificateProfile = ctlog.CertificateProfileMark
+		chain := newTestChain(t, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, nil, nil)
+		setTestRoots(t, tl, chain.root)
+
+		if _, err := tl.LogClient().AddChain(context.Background(), []ct.ASN1Cert{
+			{Data: chain.leaf}, {Data: chain.root},
+		}); err == nil {
+			t.Fatal("AddChain succeeded for serverAuth certificate in mark profile")
+		}
+	})
+
+	t.Run("TLS rejects mark-only EKU", func(t *testing.T) {
+		tl := NewEmptyTestLog(t)
+		chain := newTestChain(t, nil, []ctasn1.ObjectIdentifier{testMarkCertificateEKU}, nil)
+		setTestRoots(t, tl, chain.root)
+
+		if _, err := tl.LogClient().AddChain(context.Background(), []ct.ASN1Cert{
+			{Data: chain.leaf}, {Data: chain.root},
+		}); err == nil {
+			t.Fatal("AddChain succeeded for mark-only certificate in TLS profile")
+		}
+	})
+
+	t.Run("mark enforces configured policy", func(t *testing.T) {
+		tl := NewEmptyTestLog(t)
+		tl.Config.CertificateProfile = ctlog.CertificateProfileMark
+		tl.Config.MarkCertificatePolicies = []ctasn1.ObjectIdentifier{requiredPolicy}
+		chain := newTestChain(t, nil, []ctasn1.ObjectIdentifier{testMarkCertificateEKU}, []ctasn1.ObjectIdentifier{requiredPolicy})
+		setTestRoots(t, tl, chain.root)
+
+		if _, err := tl.LogClient().AddChain(context.Background(), []ct.ASN1Cert{
+			{Data: chain.leaf}, {Data: chain.root},
+		}); err != nil {
+			t.Fatalf("AddChain returned error: %v", err)
+		}
+	})
+}
+
+type generatedChain struct {
+	root []byte
+	leaf []byte
+}
+
+func newTestChain(t *testing.T, extKeyUsages []x509.ExtKeyUsage, unknownExtKeyUsages, policyIdentifiers []ctasn1.ObjectIdentifier) generatedChain {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	fatalIfErr(t, err)
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root"},
+		NotBefore:             time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2035, time.January, 1, 0, 0, 0, 0, time.UTC),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	fatalIfErr(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	fatalIfErr(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "example.test"},
+		NotBefore:             time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           extKeyUsages,
+		UnknownExtKeyUsage:    unknownExtKeyUsages,
+		PolicyIdentifiers:     policyIdentifiers,
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"example.test"},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootTemplate, &leafKey.PublicKey, rootKey)
+	fatalIfErr(t, err)
+
+	return generatedChain{root: rootDER, leaf: leafDER}
+}
+
+func setTestRoots(t *testing.T, tl *TestLog, root []byte) {
+	t.Helper()
+	fatalIfErr(t, tl.Log.SetRootsFromPEM(t.Context(), pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE", Bytes: root,
+	})))
+}

--- a/internal/ctlog/profile_test.go
+++ b/internal/ctlog/profile_test.go
@@ -1,0 +1,52 @@
+package ctlog
+
+import (
+	"testing"
+
+	ctasn1 "github.com/google/certificate-transparency-go/asn1"
+	"github.com/google/certificate-transparency-go/x509"
+)
+
+func TestValidateMarkCertificateProfile(t *testing.T) {
+	requiredPolicy := ctasn1.ObjectIdentifier{2, 16, 840, 1, 114413, 1, 7, 23, 4}
+	log := &Log{c: &Config{
+		CertificateProfile:      CertificateProfileMark,
+		MarkCertificatePolicies: []ctasn1.ObjectIdentifier{requiredPolicy},
+	}}
+
+	t.Run("accepts mark EKU and required policy", func(t *testing.T) {
+		cert := &x509.Certificate{
+			UnknownExtKeyUsage: []ctasn1.ObjectIdentifier{markCertificateEKU},
+			PolicyIdentifiers:  []ctasn1.ObjectIdentifier{requiredPolicy},
+		}
+		if err := log.validateCertificateProfile(cert); err != nil {
+			t.Fatalf("validateCertificateProfile returned error: %v", err)
+		}
+	})
+
+	t.Run("rejects missing mark EKU", func(t *testing.T) {
+		cert := &x509.Certificate{
+			ExtKeyUsage:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			PolicyIdentifiers: []ctasn1.ObjectIdentifier{requiredPolicy},
+		}
+		if err := log.validateCertificateProfile(cert); err == nil {
+			t.Fatal("validateCertificateProfile succeeded for certificate without mark EKU")
+		}
+	})
+
+	t.Run("rejects missing required policy", func(t *testing.T) {
+		cert := &x509.Certificate{
+			UnknownExtKeyUsage: []ctasn1.ObjectIdentifier{markCertificateEKU},
+		}
+		if err := log.validateCertificateProfile(cert); err == nil {
+			t.Fatal("validateCertificateProfile succeeded for certificate without required policy")
+		}
+	})
+}
+
+func TestValidateTLSCertificateProfile(t *testing.T) {
+	log := &Log{c: &Config{}}
+	if err := log.validateCertificateProfile(&x509.Certificate{}); err != nil {
+		t.Fatalf("default profile validation returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a mark certificate profile that validates submitted leaves with the Verified Mark Certificate EKU instead of the TLS serverAuth EKU
- add RFC 6962 get-roots fetching for mark root sources, with cached last-known-good roots after startup
- document mark certificate configuration and root refresh behavior
- add tests for config validation, root parsing, profile validation, and end-to-end AddChain behavior

## Testing

- go test ./...
- local throwaway Sunlight run against https://gorgon.ct.digicert.com/log/ct/v1/get-roots verified 8 persisted/served roots and no intended_use in log.v3.json